### PR TITLE
Derive number of people registered from WCIF instead of storing derived state

### DIFF
--- a/src/components/EventsView/index.tsx
+++ b/src/components/EventsView/index.tsx
@@ -3,6 +3,7 @@ import {
   addableEventIdsSelector,
   eventsSelector,
   numStationsSelector,
+  numRegisteredByEventSelector,
 } from "../../app/selectors";
 import { Event } from "./Event";
 import { EventId, EVENT_IDS } from "../../types";
@@ -20,6 +21,7 @@ const EventsView = () => {
   const events = useSelector(eventsSelector);
   const addableEventIds = useSelector(addableEventIdsSelector);
   const numStations = useSelector(numStationsSelector);
+  const numRegisteredByEvent = useSelector(numRegisteredByEventSelector);
 
   const makeOnUpdateRound = (eventId: EventId, roundNum: number) => {
     return (
@@ -59,9 +61,9 @@ const EventsView = () => {
         <ResetEventsButton />
       </Box>
       {EVENT_IDS.map((eventId) => {
-        const event = events[eventId];
+        const rounds = events[eventId];
 
-        if (event == null) {
+        if (!rounds) {
           return null;
         }
 
@@ -81,8 +83,8 @@ const EventsView = () => {
           <Event
             key={eventId}
             eventId={eventId}
-            numRegistered={event.numRegistered}
-            rounds={event.rounds}
+            numRegistered={numRegisteredByEvent[eventId]}
+            rounds={rounds}
             numStations={numStations}
             makeOnUpdateRound={makeOnUpdateRound}
             onAddRound={onAddRound}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type ManageableCompetition = {
 };
 
 export type Events = {
-  [E in EventId]: { rounds: Array<Round>; numRegistered: number } | null;
+  [E in EventId]: Array<Round> | null;
 };
 
 export type Round = {

--- a/src/utils/calculators.ts
+++ b/src/utils/calculators.ts
@@ -121,8 +121,7 @@ export const calcScheduleTimes = (
 
     const scheduledTime =
       scheduleEntry.type === "event"
-        ? events[scheduleEntry.eventId]?.rounds[scheduleEntry.roundNum]
-            .scheduledTime
+        ? events[scheduleEntry.eventId]?.[scheduleEntry.roundNum].scheduledTime
         : otherActivities[scheduleEntry.eventId];
     const scheduledTimeMs = parseInt(scheduledTime || "0") * 60 * 1000;
 

--- a/src/utils/wcif.ts
+++ b/src/utils/wcif.ts
@@ -209,17 +209,14 @@ export const getDefaultEventsData = ({
         parseInt(a.id[a.id.indexOf("-r") + 2]) -
         parseInt(b.id[b.id.indexOf("-r") + 2])
     );
-    events[id] = {
-      rounds: wcifRoundsToEventRounds(
-        sortedRounds,
-        id,
-        competitorLimit || 0,
-        numStations,
-        wcif.schedule,
-        wcif.persons
-      ),
-      numRegistered: numPersonsRegisteredForEvent(id, wcif.persons),
-    };
+    events[id] = wcifRoundsToEventRounds(
+      sortedRounds,
+      id,
+      competitorLimit || 0,
+      numStations,
+      wcif.schedule,
+      wcif.persons
+    );
   });
 
   return events;
@@ -330,7 +327,7 @@ export const getDefaultSchedule = (
   numOtherActivities: Record<OtherActivity, string>
 ): Schedule => {
   const scheduleEvents = EVENT_IDS.flatMap((eventId) =>
-    (events[eventId] || { rounds: [] }).rounds.map((_, roundNum) => ({
+    (events[eventId] ?? []).map((_, roundNum) => ({
       type: "event" as const,
       eventId,
       roundNum,
@@ -474,15 +471,15 @@ export const createWcifEvents = (
   originalWcifEvents: Array<WcifEvent>
 ): Array<WcifEvent> =>
   Object.entries(events)
-    .filter(([_, event]) => event?.rounds.length)
-    .map(([eventId, event]) => {
+    .filter(([_, rounds]) => rounds?.length)
+    .map(([eventId, rounds]) => {
       const originalWcifEvent = originalWcifEvents.find(
         ({ id }) => id === eventId
       );
 
       return createWcifEvent(
         eventId as EventId,
-        event?.rounds ?? [],
+        rounds ?? [],
         originalWcifEvent
       );
     });


### PR DESCRIPTION
Removes `numRegistered` from state, in favor of pulling from WCIF state directly.