### PR TITLE
Include formatVersion in WCIF PATCH

### DIFF
--- a/src/utils/wcaApi.ts
+++ b/src/utils/wcaApi.ts
@@ -67,5 +67,6 @@ export const saveWcifChanges = (
     (key) => previousWcif[key] !== newWcif[key]
   );
   if (keysDiff.length === 0) return Promise.resolve();
-  return updateWcif(newWcif.id, pick(newWcif, keysDiff), wcaAccessToken);
+  const keysForPatch = ["formatVersion", ...keysDiff];
+  return updateWcif(newWcif.id, pick(newWcif, keysForPatch), wcaAccessToken);
 };


### PR DESCRIPTION
WCIF v1.1 requires sending `formatVersion` when PATCHing a WCIF.

This updates `saveWcifChanges()` to always include `formatVersion` in the PATCH payload (alongside the diff keys), even if `formatVersion` itself wasn't modified.